### PR TITLE
Make sure that text is aligned uniformly between each joyride tip popup....

### DIFF
--- a/joyride-1.0.2.css
+++ b/joyride-1.0.2.css
@@ -19,6 +19,7 @@ body {
      -moz-border-radius: 4px;
   -webkit-border-radius: 4px;
           border-radius: 4px;
+  text-align:justify;
 }
 /* Add a little css triangle pip, older browser just miss out on the fanciness of it */
 .joyride-tip-guide span.joyride-nub {


### PR DESCRIPTION
... Because of tag insertion text-align gets inherited based on context for each popup, currently causing inconsistent formatting.
