### PR TITLE
Automatically right-align tips that are close to the right side of the browser

### DIFF
--- a/joyride-1.0.4.css
+++ b/joyride-1.0.4.css
@@ -52,6 +52,12 @@ width: 100%;
   border: solid 14px;
   border: solid 14px;
 }
+
+.joyride-tip-guide.right span.joyride-nub {
+	left: auto;
+	right: 22px;
+}
+
 .joyride-tip-guide span.joyride-nub.top {
   border-top-color: transparent !important;
   border-left-color: transparent !important;

--- a/jquery.joyride-1.0.4.js
+++ b/jquery.joyride-1.0.4.js
@@ -119,8 +119,13 @@
         currentParentHeight = parentElement.outerHeight(),
         currentTipHeight = currentTip.outerHeight(),
         nubHeight = Math.ceil($('.joyride-nub').outerHeight() / 2),
+        currentTipWidth = Math.ceil($('.joyride-tip-guide').outerWidth()),
+        nubOffset = currentTip.find('.joyride-nub').css('left'),
         tipOffset = 0;
 
+        if(currentTipPosition != null && currentTipPosition.left+currentTipWidth*1.2 > $(window).innerWidth()) {
+            currentTip.addClass('right');
+        }
         if (currentTip.length === 0) return;
 
         if (count < tipContent.length) {
@@ -167,17 +172,23 @@
             }
           } else {
             if (settings.tipLocation == "bottom") {
-              currentTip.offset({top: (currentTipPosition.top + currentParentHeight + nubHeight),
-                left: (currentTipPosition.left - bodyOffset.left)});
+              currentTip.offset({
+              	  top: (currentTipPosition.top + currentParentHeight + nubHeight),
+                  left: currentTip.hasClass('right') ? (currentTipPosition.left - bodyOffset.left-currentTipWidth + 3*parseInt(nubOffset)) : (currentTipPosition.left - bodyOffset.left)
+                  });
               currentTip.children('.joyride-nub').addClass('top').removeClass('bottom');
             } else if (settings.tipLocation == "top") {
               if (currentTipHeight >= currentTipPosition.top) {
-                currentTip.offset({top: ((currentTipPosition.top + currentParentHeight + nubHeight) - bodyOffset.top),
-                  left: (currentTipPosition.left - bodyOffset.left)});
+                currentTip.offset({
+                	top: ((currentTipPosition.top + currentParentHeight + nubHeight) - bodyOffset.top),
+                  	left: currentTip.hasClass('right') ? (currentTipPosition.left - bodyOffset.left-currentTipWidth + 3*parseInt(nubOffset)) : (currentTipPosition.left - bodyOffset.left)
+                });
                 currentTip.children('.joyride-nub').addClass('top').removeClass('bottom');
               } else {
-                currentTip.offset({top: ((currentTipPosition.top) - (currentTipHeight + bodyOffset.top + nubHeight)),
-                  left: (currentTipPosition.left - bodyOffset.left)});
+                currentTip.offset({
+                	top: ((currentTipPosition.top) - (currentTipHeight + bodyOffset.top + nubHeight)),
+                  	left: currentTip.hasClass('right') ? (currentTipPosition.left - bodyOffset.left-currentTipWidth + 3*parseInt(nubOffset)) : (currentTipPosition.left - bodyOffset.left)
+                });
                 currentTip.children('.joyride-nub').addClass('bottom').removeClass('top');
               }
             }


### PR DESCRIPTION
I've made a small modification to "right-align" tour steps close to the right side of the browser window (where "close" means that the anchor to which the tooltip is attached is >=120% of a joyride tooltip width from the right edge).

Live demos are here http://joyride-rails-demo.herokuapp.com/

The first tip of each demo is what I'm calling "right-aligned", if you make your browser window width sufficiently narrow.
