### PR TITLE
Fix issue when tips contain list elements themselves.

### DIFF
--- a/jquery.joyride-2.0.1.js
+++ b/jquery.joyride-2.0.1.js
@@ -56,7 +56,7 @@
             settings.$window = $(window);
             settings.$content_el = $(this);
             settings.body_offset = $(settings.tipContainer).position();
-            settings.$tip_content = $('li', settings.$content_el);
+            settings.$tip_content = $('> li', settings.$content_el);
             settings.paused = false;
             settings.attempts = 0;
 


### PR DESCRIPTION
The current $tip_content selector selects _all_ list elements within the tip content collection, not just the top level parent tips, resulting in unwanted behavior. This minor change fixes that behavior.
