### PR TITLE
Adding deep copy support for better template overrides

### DIFF
--- a/jquery.joyride-2.0.2.js
+++ b/jquery.joyride-2.0.2.js
@@ -48,7 +48,7 @@
         return this.each(function () {
 
           if ($.isEmptyObject(settings)) {
-            settings = $.extend(defaults, opts);
+            settings = $.extend(true, defaults, opts);
 
             // non configureable settings
             settings.document = window.document;


### PR DESCRIPTION
Switching the $.extend method to a deep copy allows users to override specific templates individually rather than the entire template object.

For example, without a deep copy (as the plugin currently is) if a user initializes orbit with:

$.orbit({
    template: {
        link: '<a>Something</a>'
    }
});

...the result will be the template object, in its entirety, will be completely overwritten. The templates for timer, tip, wrapper and button will no longer exist.

By toggling deep copy support on our extend function, the override works as expected (in this example, link will be overwritten, but the other templates will still exist).
