### PR TITLE
New option "scroll" to enable/disable scrolling

### DIFF
--- a/jquery.joyride-2.0.3.js
+++ b/jquery.joyride-2.0.3.js
@@ -15,6 +15,7 @@
       'version'              : '2.0.3',
       'tipLocation'          : 'bottom',  // 'top' or 'bottom' in relation to parent
       'nubPosition'          : 'auto',    // override on a per tooltip bases
+      'scroll'               : true,      // whether to scroll to tips
       'scrollSpeed'          : 300,       // Page scrolling speed in milliseconds
       'timer'                : 0,         // 0 = no timer , all other numbers = timer in milliseconds
       'startTimerOnClick'    : true,      // true or false - true requires clicking the first button start the timer
@@ -221,7 +222,7 @@
             settings.tipSettings.tipLocationPattern = settings.tipLocationPatterns[settings.tipSettings.tipLocation];
 
             // scroll if not modal
-            if (!/body/i.test(settings.$target.selector)) {
+            if (!/body/i.test(settings.$target.selector) && settings.scroll) {
               methods.scroll_to();
             }
 


### PR DESCRIPTION
Using this on our homepage is awesome, but we can't have the page scrolling down when it first loads. I'd like to see this as a tip setting eventually, to enable/disable scrolling for each stop of the ride.
