### PR TITLE
Adds some a11y improvements to joyride.

### DIFF
--- a/jquery.joyride-2.0.3.js
+++ b/jquery.joyride-2.0.3.js
@@ -149,7 +149,7 @@
       }, 
 
       tip_template : function (opts) {
-        var $blank, content;
+        var $blank, content, $wrapper;
 
         opts.tip_class = opts.tip_class || '';
 
@@ -159,7 +159,14 @@
           settings.template.link +
           methods.timer_instance(opts.index);
 
-        $blank.append($(settings.template.wrapper));
+        $wrapper = $(settings.template.wrapper);
+        if (opts.li.attr('data-aria-labelledby')) {
+          $wrapper.attr('aria-labelledby', opts.li.attr('data-aria-labelledby'))
+        }
+        if (opts.li.attr('data-aria-describedby')) {
+          $wrapper.attr('aria-describedby', opts.li.attr('data-aria-describedby'))
+        }
+        $blank.append($wrapper);
         $blank.first().attr('data-index', opts.index);
         $('.joyride-content-wrapper', $blank).append(content);
 


### PR DESCRIPTION
1) Adds role=dialog to the wrapper
2) Adds focus to the 'next' button so keyboard users can navigate through the joyride tour.

Ideally we'd be able to add a 'aria-labelledby' attribute to the wrapper as well but as the content inside the tour item isn't fixed, we can't really know what form that could be.
