### PR TITLE
Adding modal background option, and an expose element feature 

### DIFF
--- a/demo/demo.html
+++ b/demo/demo.html
@@ -111,13 +111,15 @@
     <script>
       $(window).load(function() {
         $('#joyRideTipContent').joyride({
-            autoStart : true,
-            postStepCallback : function (index, tip) {
-              if (index == 2) {
-                $(this).joyride('set_li', false, 1);
-              }
-            }
-          });
+          autoStart : true,
+          postStepCallback : function (index, tip) {
+          if (index == 2) {
+            $(this).joyride('set_li', false, 1);
+          }
+        },
+        modal:true,
+        expose: true
+        });
       });
     </script>
 

--- a/joyride-2.0.3.css
+++ b/joyride-2.0.3.css
@@ -238,3 +238,20 @@ body {
   left: 0;
   cursor: pointer;
 }
+
+.joyride-expose-wrapper {
+    background-color: #ffffff;
+    position: absolute;
+    z-index: 102;
+    -moz-box-shadow: 0px 0px 30px #ffffff;
+    -webkit-box-shadow: 0px 0px 30px #ffffff;
+    box-shadow: 0px 0px 30px #ffffff;
+}
+
+.joyride-expose-cover {
+    background: transparent;
+    position: absolute;
+    z-index: 10000;
+    top: 0px;
+    left: 0px;
+}


### PR DESCRIPTION
added a modal option for those that want the page darkened out during the tour.

created an expose feature to expose the highlighted elements that are covered by the modal during the tour. see screenshot...

![expose_on_modal](https://f.cloud.github.com/assets/213511/137593/a4a1897a-7174-11e2-87af-dd6d2452f939.png)

added 2 options to turn these features on and off.

modal: false(default) // setting this to true makes the whole tour happen over a modal background
expose: false(default) //setting this and modal to true causes the element to be exposed  during a modal'd tour as seen in the screenshot.

I also added 3 more callbacks: preRideCallback, preStepCallback, and postExposeCallback

didn't change any filenames or versions, but since I wrote this and its very helpful to me I figured I'd share :)
