### PR TITLE
Destroying Joyride when an instance has never been initialized throws an exception.

### DIFF
--- a/jquery.joyride-2.0.3.js
+++ b/jquery.joyride-2.0.3.js
@@ -359,7 +359,10 @@
       },
 
       destroy : function () {
-        settings.$document.off('.joyride');
+        if(!$.isEmptyObject(settings)){
+          settings.$document.off('.joyride');
+        }
+        
         $(window).off('.joyride');
         $('.joyride-close-tip, .joyride-next-tip, .joyride-modal-bg').off('.joyride');
         $('.joyride-tip-guide, .joyride-modal-bg').remove();


### PR DESCRIPTION
Added a check in the destroy function to determine if the settings object is empty.  This was  throwing an error when destroying joyride when it was never initialized.
