### PR TITLE
Avoid Uncaught TypeError: Cannot call method 'offset' of undefined error when using autoStart: false

### DIFF
--- a/jquery.joyride-2.0.3.js
+++ b/jquery.joyride-2.0.3.js
@@ -120,10 +120,12 @@
             });
 
             settings.$window.bind('resize.joyride', function (e) {
-              if (methods.is_phone()) {
-                methods.pos_phone();
-              } else {
-                methods.pos_default();
+              if(settings.$li){
+                if (methods.is_phone()) {
+                  methods.pos_phone();
+                } else {
+                  methods.pos_default();
+                }
               }
             });
           } else {


### PR DESCRIPTION
The pull request #68 which added an autoStart option added a bug. When the autoStart option is set to false and the resize.joyride event is triggered (for example when the user resize his browser window) a console error: "Uncaught TypeError: Cannot call method 'offset' of undefined " is thrown (as described in the #78 issue).
This happen because the show('init') function which initialize different variables is not called when the autoStart option is set to false.

To still be able to use autoStart: false, this pull request add a check to avoid callling the pos_default and pos_phone methods which generate the undefine error.

This way, it's still possible to avoid starting the tour on page load and rather starts it later on. For example, when the user clicks on a button.
