### PR TITLE
Bug fix for "autoStart" option introuction.

### DIFF
--- a/jquery.joyride-2.0.3.js
+++ b/jquery.joyride-2.0.3.js
@@ -77,24 +77,14 @@
               settings.cookieMonster = false;
             }
 
-            // generate the tips and insert into dom.
-            if (!settings.cookieMonster || !$.cookie(settings.cookieName)) {
-
-              settings.$tip_content.each(function (index) {
-                methods.create({$li : $(this), index : index});
-              });
-
-              // show first tip
-              if(settings.autoStart)
-              {
-                if (!settings.startTimerOnClick && settings.timer > 0) {
-                  methods.show('init');
-                  methods.startTimer();
-                } else {
-                  methods.show('init');
-                }
+            if(settings.autoStart)
+            {
+              settings.autoStart = false;
+              
+              // generate the tips and insert into dom.
+              if (!settings.cookieMonster || !$.cookie(settings.cookieName)) {
+                methods.restart();
               }
-
             }
 
             settings.$document.on('click.joyride', '.joyride-next-tip, .joyride-modal-bg', function (e) {
@@ -117,14 +107,6 @@
             settings.$document.on('click.joyride', '.joyride-close-tip', function (e) {
               e.preventDefault();
               methods.end();
-            });
-
-            settings.$window.bind('resize.joyride', function (e) {
-              if (methods.is_phone()) {
-                methods.pos_phone();
-              } else {
-                methods.pos_default();
-              }
             });
           } else {
             methods.restart();
@@ -401,13 +383,27 @@
       restart : function () {
         if(!settings.autoStart)
         {
+          settings.autoStart = true;
+
+          settings.$tip_content.each(function (index) {
+            methods.create({$li : $(this), index : index});
+          });
+
+          // show first tip
           if (!settings.startTimerOnClick && settings.timer > 0) {
             methods.show('init');
             methods.startTimer();
           } else {
             methods.show('init');
           }
-          settings.autoStart = true;
+
+          settings.$window.bind('resize.joyride', function (e) {
+            if (methods.is_phone()) {
+              methods.pos_phone();
+            } else {
+              methods.pos_default();
+            }
+          });
         }
         else
         {


### PR DESCRIPTION
Fixes the bug introduced by autoStart option. It also fixes the same bug when cookieMonster is on and a cookie exists. It simply postpones the binding of 'resize.joyride' to after the first is tip is presented. Not ideal fix as it reuses "autoStart" as an initialization flag.
