### PR TITLE
Add support for data-selector attribute

### DIFF
--- a/demo/demo.html
+++ b/demo/demo.html
@@ -97,7 +97,7 @@
         <h2>Stop #4</h2>
         <p>It works as a modal too!</p>
       </li>
-      <li data-id="numero5" data-button="Close">
+      <li data-selector="div.row:has(#numero1) img" data-button="Close">
         <h2>Stop #5</h2>
         <p>Now what are you waiting for? Add this to your projects and get the most out of your apps!</p>
       </li>

--- a/jquery.joyride-2.0.3.js
+++ b/jquery.joyride-2.0.3.js
@@ -389,11 +389,14 @@
       set_target : function () {
         var cl = settings.$li.attr('data-class'),
             id = settings.$li.attr('data-id'),
+            selector = settings.$li.attr('data-selector'),
             $sel = function () {
               if (id) {
                 return $(settings.document.getElementById(id));
               } else if (cl) {
                 return $('.' + cl).first();
+              } else if (selector) {
+                return $(selector).first();
               } else {
                 return $('body');
               }


### PR DESCRIPTION
Hey guys,

thanks for the great plugin! We wanted to use it to provide a feature tour for our existing web-based software solutions. But we don't like to add extra-id's or classes just to be able to target elements with joyride. So I added support for a "data-selector" attribute which allows selecting the target element with a complex jQuery-selector instead of just ID or class.

Hope you like it :-)
