### PR TITLE
Correct tooltip alignment based on nub position

### DIFF
--- a/jquery.joyride-2.0.3.js
+++ b/jquery.joyride-2.0.3.js
@@ -1,4 +1,4 @@
-/*
+  /*
  * jQuery Foundation Joyride Plugin 2.0.3
  * http://foundation.zurb.com
  * Copyright 2012, ZURB
@@ -472,6 +472,10 @@
               settings.$next_tip.css({
                 top: (settings.$target.offset().top + nub_height + settings.$target.outerHeight()),
                 left: settings.$target.offset().left});
+
+              if (/right/i.test(settings.tipSettings.nubPosition)) {
+                settings.$next_tip.css('left', settings.$target.offset().left - settings.$next_tip.outerWidth() + settings.$target.outerWidth());
+              }
 
               methods.nub_position($nub, settings.tipSettings.nubPosition, 'top');
 


### PR DESCRIPTION
Currently when a tooltip is configured to hang off the bottom with the nub on the right
(`tipLocation:bottom;nubLocation:top-right`), the nub is no longer pointing at the target.

This patch moves the tooltip so that the right side of the tooltip lines up with the right side of the target element.

The same code is repeated for both the bottom and top blocks, so it should probably be factored out, but I wasn't sure where to put it, but if you let me know what to name a helper method, I can change this.
