### PR TITLE
postRideCallback argument 'completed' to check if the user has completed all ride

### DIFF
--- a/jquery.joyride-2.0.3.js
+++ b/jquery.joyride-2.0.3.js
@@ -805,7 +805,9 @@
       },
 
       end : function (completed) {
+        // completed: true if user has completed all ride, otherwise false. default: true
         var completed = (typeof completed === "undefined") ? true : completed;
+
         if (settings.cookieMonster) {
           $.cookie(settings.cookieName, 'ridden', { expires: 365, domain: settings.cookieDomain });
         }


### PR DESCRIPTION
postRideCallback now passing a third argument named 'completed'.
This is set to true if the user has completed all the ride(has seen all tips), otherwise is set to false in case the user has not completed the ride (e.g.: on ESC keypress or on 'a.joyride-close-tip' click.
