### PR TITLE
Fixing an issue where you cannot click a link directly above the nub

### DIFF
--- a/joyride-2.1.css
+++ b/joyride-2.1.css
@@ -68,7 +68,8 @@ body {
   border-top-color: transparent !important;
   border-left-color: transparent !important;
   border-right-color: transparent !important;
-  top: -28px;
+  border-top-width: 0;
+  top: -14px;
   bottom: none;
 }
 
@@ -85,7 +86,8 @@ body {
   border-bottom-color: transparent !important;
   border-left-color: transparent !important;
   border-right-color: transparent !important;
-  bottom: -28px;
+  border-bottom-width: 0;
+  bottom: -14px;
   bottom: none;
 }
 
@@ -95,10 +97,11 @@ body {
   border-top-color: transparent !important;
   border-right-color: transparent !important;
   border-bottom-color: transparent !important;
+  border-right-width: 0;
   top: 22px;
   bottom: none;
   left: auto;
-  right: -28px;
+  right: -14px;
 }
 
 .joyride-tip-guide span.joyride-nub.left {
@@ -107,8 +110,9 @@ body {
   border-top-color: transparent !important;
   border-left-color: transparent !important;
   border-bottom-color: transparent !important;
+  border-left-width: 0;
   top: 22px;
-  left: -28px;
+  left: -14px;
   right: auto;
   bottom: none;
 }
@@ -119,7 +123,8 @@ body {
   border-top-color: transparent !important;
   border-left-color: transparent !important;
   border-right-color: transparent !important;
-  top: -28px;
+  border-top-width: 0;
+  top: -14px;
   bottom: none;
   left: auto;
   right: 28px;


### PR DESCRIPTION
If your target element is clickable, like a link, you cannot click directly above (below, left of, or right of) the nub. It's a small area where the transparent top (bottom, left, right) border of the nub is overlaid on the element. It's a small change, but it fixes it. 

Here's a gist to recreate the issue: https://gist.github.com/mcicoria/6094454

Here are the before and after shots of the borders that were transparent at #f00:

![Before the changes](https://f.cloud.github.com/assets/1305676/866680/bc90faec-f6a4-11e2-9a81-1fd34e6f1df2.png)
![After the changes](https://f.cloud.github.com/assets/1305676/866681/eda0bf00-f6a4-11e2-8066-d7a4b42abbfb.png)
