### PR TITLE
Adding a scrollOffset option to the settings for fixed headers

### DIFF
--- a/jquery.joyride-2.1.js
+++ b/jquery.joyride-2.1.js
@@ -17,6 +17,7 @@
       'nubPosition'          : 'auto',    // override on a per tooltip bases
       'scroll'               : true,      // whether to scroll to tips
       'scrollSpeed'          : 300,       // Page scrolling speed in milliseconds
+      'scrollOffset'         : 0,         // Scrolling offset for fixed headers
       'timer'                : 0,         // 0 = no timer , all other numbers = timer in milliseconds
       'autoStart'            : false,     // true or false - false tour starts when restart called
       'startTimerOnClick'    : true,      // true or false - true requires clicking the first button start the timer
@@ -419,7 +420,7 @@
         tipOffset = Math.ceil(settings.$target.offset().top - window_half + settings.$next_tip.outerHeight());
 
         $("html, body").stop().animate({
-          scrollTop: tipOffset
+          scrollTop: tipOffset - settings.scrollOffset
         }, settings.scrollSpeed);
       },
 


### PR DESCRIPTION
I'm using Joyride on an application with a fixed header, and needed to be able to offset the `scrollTop` so that when `scroll` is set to `true`, tips that are at the top of the main container wouldn't be scrolled to (underneath the fixed header). I added a `scrollOffset` option to the settings, which is defaulted to `0`. I thought this would be a pretty common scenario that others would benefit from.
