### PR TITLE
Breakpoint option for setting when the mobile layout gets triggered

### DIFF
--- a/jquery.joyride-2.1.js
+++ b/jquery.joyride-2.1.js
@@ -17,6 +17,7 @@
       'nubPosition'          : 'auto',    // override on a per tooltip bases
       'scroll'               : true,      // whether to scroll to tips
       'scrollSpeed'          : 300,       // Page scrolling speed in milliseconds
+      'breakpoint'           : 768,       // Sets the point in px at which the tips will switch to a full-width layout
       'timer'                : 0,         // 0 = no timer , all other numbers = timer in milliseconds
       'autoStart'            : false,     // true or false - false tour starts when restart called
       'startTimerOnClick'    : true,      // true or false - true requires clicking the first button start the timer
@@ -354,10 +355,10 @@
       // detect phones with media queries if supported.
       is_phone : function () {
         if (Modernizr) {
-          return Modernizr.mq('only screen and (max-width: 767px)');
+          return Modernizr.mq('only screen and (max-width: ' + settings.breakpoint + 'px)');
         }
 
-        return (settings.$window.width() < 767) ? true : false;
+        return (settings.$window.width() < settings.breakpoint) ? true : false;
       },
 
       support_localstorage : function () {


### PR DESCRIPTION
The plugin has the tips switch to a mobile layout at `768px` by default, but in the case that I'm using it in I didn't need the mobile layout to be triggered until smaller than that, so I thought adding a `breakpoint` option to the settings would be helpful. If left untouched the default is still `768px`, but if desired you can set your own:  

```
$('#joyride').joyride({
    breakpoint:600
})
```

Remember, this is a `only screen and max-width()` media query. 
