### PR TITLE
Instead of "ridden" for cookie contents, store the time of the ride.

### DIFF
--- a/jquery.joyride-2.1.js
+++ b/jquery.joyride-2.1.js
@@ -825,7 +825,7 @@
 
       end : function () {
         if (settings.cookieMonster) {
-          $.cookie(settings.cookieName, 'ridden', { expires: 365, domain: settings.cookieDomain, path: settings.cookiePath });
+          $.cookie(settings.cookieName, Math.round(+new Date()/1000), { expires: 365, domain: settings.cookieDomain, path: settings.cookiePath });
         }
 
         if (settings.localStorage) {


### PR DESCRIPTION
Rather than log "ridden" in the cookie which gives us no real information, log the time the cookie was created.  We can then use the cookie later to decide it we want to reshow the tour element(s).

Also suggest making the expiration on cookies a setting rather than a default 365 days, but I didn't take that on here.
