### PR TITLE
Unbinding resize events when the tour is cancelled

### DIFF
--- a/jquery.joyride-2.1.js
+++ b/jquery.joyride-2.1.js
@@ -825,6 +825,12 @@
 
       end : function (isAborted) {
         isAborted = isAborted || false;
+
+        // Unbind resize events.
+        if (isAborted) {
+          settings.$window.unbind('resize.joyride');
+        }
+
         if (settings.cookieMonster) {
           $.cookie(settings.cookieName, 'ridden', { expires: 365, domain: settings.cookieDomain, path: settings.cookiePath });
         }


### PR DESCRIPTION
I found that hitting ESC or the cancel button didn't unbind resize events, so that when I resized/zoomed the modal background would fade back in and, when clicked, would resume the tour.
