### PR TITLE
Add jQuery 3 support to 2.1.x branch

### DIFF
--- a/jquery.joyride-2.1.js
+++ b/jquery.joyride-2.1.js
@@ -132,7 +132,7 @@
               methods.end(true /* isAborted */);
             });
 
-            settings.$window.bind('resize.joyride', function (e) {
+            settings.$window.on('resize.joyride', function (e) {
               if(settings.$li){
               if(settings.exposed && settings.exposed.length>0){
                 var $els = $(settings.exposed);
@@ -279,7 +279,7 @@
             }
 
             // scroll if not modal
-            if (!/body/i.test(settings.$target.selector) && settings.scroll) {
+            if (!settings.$target.is("body") && settings.scroll) {
               methods.scroll_to();
             }
 
@@ -476,7 +476,7 @@
           settings.$next_tip.show();
         }
 
-        if (!/body/i.test(settings.$target.selector)) {
+        if (!settings.$target.is("body")) {
             var
               topAdjustment = settings.tipSettings.tipAdjustmentY ? parseInt(settings.tipSettings.tipAdjustmentY) : 0,
               leftAdjustment = settings.tipSettings.tipAdjustmentX ? parseInt(settings.tipSettings.tipAdjustmentX) : 0;
@@ -564,7 +564,7 @@
           settings.$next_tip.show();
         }
 
-        if (!/body/i.test(settings.$target.selector)) {
+        if (!settings.$target.is("body")) {
 
           if (methods.top()) {
 
@@ -618,7 +618,7 @@
           randId = 'expose-'+Math.floor(Math.random()*10000);
         if (arguments.length>0 && arguments[0] instanceof $){
           el = arguments[0];
-        } else if(settings.$target && !/body/i.test(settings.$target.selector)){
+        } else if(settings.$target && !settings.$target.is("body")){
           el = settings.$target;
         }  else {
           return false;
@@ -673,7 +673,7 @@
           clearAll = false;
         if (arguments.length>0 && arguments[0] instanceof $){
           el = arguments[0];
-        } else if(settings.$target && !/body/i.test(settings.$target.selector)){
+        } else if(settings.$target && !settings.$target.is("body")){
           el = settings.$target;
         }  else {
           return false;
@@ -828,7 +828,7 @@
 
         // Unbind resize events.
         if (isAborted) {
-          settings.$window.unbind('resize.joyride');
+          settings.$window.off('resize.joyride');
         }
 
         if (settings.cookieMonster) {


### PR DESCRIPTION
In Drupal 8, we use the joyride plugin to power the tour module.

We're hoping to update to jQuery 3 in Drupal 8.4.0 but don't want to move away from the 2.1.x branch as we have a lot of styling that is made to support the markup/classes as well as a Yaml based API that supports the existing data attributes. We've looked at the 3.x branch and would like to avoid adding the lightweight foundation framework that the solo plugin comes with.

These minor changes will make the 2.1.x branch support jQuery 3 and are backwards compatible to jQuery 1.7.

We're hoping you'll consider them.