### PR TITLE
docs: Fix simple typo, specifc -> specific

### DIFF
--- a/dist/foundation.joyride.js
+++ b/dist/foundation.joyride.js
@@ -114,7 +114,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
       value: function _render(structure) {
         for (var s in structure) {
           var options = $.extend({}, this.options, structure[s]),
-              // if specifc item has config, this should overwrite global settings
+              // if specific item has config, this should overwrite global settings
           $item;
 
           if (options.$target.length) {

--- a/dist/solo.joyride.js
+++ b/dist/solo.joyride.js
@@ -2942,7 +2942,7 @@ function _classCallCheck(instance, Constructor) {
         for (var s in structure) {
           var options = $.extend({}, this.options, structure[s]),
 
-          // if specifc item has config, this should overwrite global settings
+          // if specific item has config, this should overwrite global settings
           $item;
 
           if (options.$target.length) {

--- a/js/joyride.js
+++ b/js/joyride.js
@@ -100,7 +100,7 @@
      */
     _render(structure) {
       for (var s in structure) {
-        var options = $.extend({}, this.options, structure[s]),// if specifc item has config, this should overwrite global settings
+        var options = $.extend({}, this.options, structure[s]),// if specific item has config, this should overwrite global settings
           $item;
 
         if (options.$target.length) { // target element exists, create tooltip


### PR DESCRIPTION
There is a small typo in dist/foundation.joyride.js, dist/solo.joyride.js, js/joyride.js.

Should read `specific` rather than `specifc`.

